### PR TITLE
refactor: apply namespaced imports using @<folder-name> across project

### DIFF
--- a/nodeeats/jest.config.js
+++ b/nodeeats/jest.config.js
@@ -35,12 +35,22 @@ module.exports = {
   // Path mappings to support TypeScript aliases
   moduleNameMapper: {
     '^src/(.*)$': '<rootDir>/src/$1',
+    '^@dto/(.*)$': '<rootDir>/src/dto/$1',
     '^@entities/(.*)$': '<rootDir>/src/entities/$1',
-    '^@repositories/(.*)$': '<rootDir>/src/repositories/$1',
-    '^@mocks/(.*)$': '<rootDir>/tests/mocks/$1',
-    '^@services/(.*)$': '<rootDir>/src/services/$1',
+    '^@events/(.*)$': '<rootDir>/src/events/$1',
     '^@handlers/(.*)$': '<rootDir>/src/handlers/$1',
+    '^@listeners/(.*)$': '<rootDir>/src/events/listeners/$1',
+    '^@middlewares/(.*)$': '<rootDir>/src/middlewares/$1',
+    '^@mocks/(.*)$': '<rootDir>/tests/mocks/$1',
+    '^@providers/(.*)$': '<rootDir>/src/providers/$1',
+    '^@routes/(.*)$': '<rootDir>/src/routes/$1',
+    '^@requests/(.*)$': '<rootDir>/src/requests/$1',
+    '^@responses/(.*)$': '<rootDir>/src/responses/$1',
+    '^@repositories/(.*)$': '<rootDir>/src/repositories/$1',
+    '^@services/(.*)$': '<rootDir>/src/services/$1',
+    '^@customTypes/(.*)$': '<rootDir>/src/types/$1',
     '^@utils/(.*)$': '<rootDir>/src/utils/$1',
+    '^@validates/(.*)$': '<rootDir>/src/validates/$1',
   },
 
   // Configures Jest to automatically clear mocks before each test

--- a/nodeeats/src/dto/requests/createCategoryRequest.dto.ts
+++ b/nodeeats/src/dto/requests/createCategoryRequest.dto.ts
@@ -1,6 +1,5 @@
 import { ICategory } from '@entities/category.entity';
-
-import { CreateCategoryValidate } from '../../validates/category.validate';
+import { CreateCategoryValidate } from '@validates/category.validate';
 
 export class CreateCategoryRequestDto {
   name: string;

--- a/nodeeats/src/dto/requests/createRestaurantRequest.dto.ts
+++ b/nodeeats/src/dto/requests/createRestaurantRequest.dto.ts
@@ -1,6 +1,5 @@
 import { IRestaurant } from '@entities/restaurant.entity';
-
-import { CreateRestaurantValidate } from '../../validates/restaurant.validate';
+import { CreateRestaurantValidate } from '@validates/restaurant.validate';
 
 export class CreateRestaurantRequestDto {
   name: string;

--- a/nodeeats/src/dto/requests/createUserRequest.dto.ts
+++ b/nodeeats/src/dto/requests/createUserRequest.dto.ts
@@ -1,5 +1,5 @@
-import { IUser } from '../../entities/user.entity';
-import { CreateUserValidate } from '../../validates/user.validate';
+import { IUser } from '@entities/user.entity';
+import { CreateUserValidate } from '@validates/user.validate';
 
 export class CreateUserRequestDto {
   name: string;

--- a/nodeeats/src/dto/requests/updateCategoryRequest.dto.ts
+++ b/nodeeats/src/dto/requests/updateCategoryRequest.dto.ts
@@ -1,6 +1,5 @@
 import { ICategory } from '@entities/category.entity';
-
-import { UpdateCategoryValidate } from '../../validates/category.validate';
+import { UpdateCategoryValidate } from '@validates/category.validate';
 
 export class UpdateCategoryRequestDto {
   categoryNumber: string;

--- a/nodeeats/src/dto/requests/updateRestaurantRequest.dto.ts
+++ b/nodeeats/src/dto/requests/updateRestaurantRequest.dto.ts
@@ -1,8 +1,7 @@
 import mongoose from 'mongoose';
 
 import { IRestaurant } from '@entities/restaurant.entity';
-
-import { UpdateRestaurantValidate } from '../../validates/restaurant.validate';
+import { UpdateRestaurantValidate } from '@validates/restaurant.validate';
 
 export class UpdateRestaurantRequestDto {
   restaurantNumber: mongoose.Types.ObjectId;

--- a/nodeeats/src/dto/requests/updateUserRequest.dto.ts
+++ b/nodeeats/src/dto/requests/updateUserRequest.dto.ts
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 
-import { IUser } from '../../entities/user.entity';
-import { UpdateUserValidate } from '../../validates/user.validate';
+import { IUser } from '@entities/user.entity';
+import { UpdateUserValidate } from '@validates/user.validate';
 
 export class UpdateUserRequestDto {
   userNumber: mongoose.Types.ObjectId;

--- a/nodeeats/src/dto/responses/userResponse.dto.ts
+++ b/nodeeats/src/dto/responses/userResponse.dto.ts
@@ -1,4 +1,4 @@
-import { IUser } from '../../entities/user.entity';
+import { IUser } from '@entities/user.entity';
 
 export class UserResponseDto {
   userNumber: string;

--- a/nodeeats/src/events/listeners/category.listener.ts
+++ b/nodeeats/src/events/listeners/category.listener.ts
@@ -1,5 +1,5 @@
-import { eventEmitter } from '../../providers/eventEmitter.provider';
-import { logger } from '../../providers/logger.provider';
+import { eventEmitter } from '@providers/eventEmitter.provider';
+import { logger } from '@providers/logger.provider';
 export function registerCategoryListeners() {
   eventEmitter.on('category.created', payload => {
     logger.info(`[category.created] ${JSON.stringify(payload)}`);

--- a/nodeeats/src/events/listeners/database.listener.ts
+++ b/nodeeats/src/events/listeners/database.listener.ts
@@ -1,5 +1,5 @@
-import { eventEmitter } from '../../providers/eventEmitter.provider';
-import { logger } from '../../providers/logger.provider';
+import { eventEmitter } from '@providers/eventEmitter.provider';
+import { logger } from '@providers/logger.provider';
 export function registerDatabaseListeners() {
   eventEmitter.on('database.connected', payload => {
     logger.info(`[database.connected] ${JSON.stringify(payload)}`);

--- a/nodeeats/src/events/listeners/restaurant.listener.ts
+++ b/nodeeats/src/events/listeners/restaurant.listener.ts
@@ -1,5 +1,5 @@
-import { eventEmitter } from '../../providers/eventEmitter.provider';
-import { logger } from '../../providers/logger.provider';
+import { eventEmitter } from '@providers/eventEmitter.provider';
+import { logger } from '@providers/logger.provider';
 export function registerRestaurantListeners() {
   eventEmitter.on('restaurant.created', payload => {
     logger.info(`[restaurant.created] ${JSON.stringify(payload)}`);

--- a/nodeeats/src/events/listeners/user.listener.ts
+++ b/nodeeats/src/events/listeners/user.listener.ts
@@ -1,5 +1,5 @@
-import { eventEmitter } from '../../providers/eventEmitter.provider';
-import { logger } from '../../providers/logger.provider';
+import { eventEmitter } from '@providers/eventEmitter.provider';
+import { logger } from '@providers/logger.provider';
 export function registerUserListeners() {
   eventEmitter.on('user.created', payload => {
     logger.info(`[user.created] ${JSON.stringify(payload)}`);

--- a/nodeeats/src/events/register.listener.ts
+++ b/nodeeats/src/events/register.listener.ts
@@ -1,7 +1,7 @@
-import { registerCategoryListeners } from './listeners/category.listener';
-import { registerDatabaseListeners } from './listeners/database.listener';
-import { registerRestaurantListeners } from './listeners/restaurant.listener';
-import { registerUserListeners } from './listeners/user.listener';
+import { registerCategoryListeners } from '@listeners/category.listener';
+import { registerDatabaseListeners } from '@listeners/database.listener';
+import { registerRestaurantListeners } from '@listeners/restaurant.listener';
+import { registerUserListeners } from '@listeners/user.listener';
 
 export function registerAllListeners() {
   registerUserListeners();

--- a/nodeeats/src/handlers/category.handler.ts
+++ b/nodeeats/src/handlers/category.handler.ts
@@ -1,15 +1,14 @@
 import { Request, Response } from 'express';
 import { injectable, inject } from 'tsyringe';
 
+import { CategoryFilter } from '@customTypes/categoryFilter.type';
+import { CreateCategoryRequestDto } from '@dto/requests/createCategoryRequest.dto';
+import { UpdateCategoryRequestDto } from '@dto/requests/updateCategoryRequest.dto';
+import { CategoryResponseDto } from '@dto/responses/categoryResponse.dto';
 import { ICategory } from '@entities/category.entity';
 import { CategoryService } from '@services/category.service';
-
-import { CreateCategoryRequestDto } from '../dto/requests/createCategoryRequest.dto';
-import { UpdateCategoryRequestDto } from '../dto/requests/updateCategoryRequest.dto';
-import { CategoryResponseDto } from '../dto/responses/categoryResponse.dto';
-import { CategoryFilter } from '../types/categoryFilter.type';
-import { handleRequest } from '../utils/handleRequest.util';
-import { pagination } from '../utils/pagination.util';
+import { handleRequest } from '@utils/handleRequest.util';
+import { pagination } from '@utils/pagination.util';
 
 @injectable()
 export class CategoryHandler {

--- a/nodeeats/src/handlers/restaurant.handler.ts
+++ b/nodeeats/src/handlers/restaurant.handler.ts
@@ -1,15 +1,14 @@
 import { Request, Response } from 'express';
 import { injectable, inject } from 'tsyringe';
 
+import { RestaurantFilter } from '@customTypes/restaurantFilter.type';
+import { CreateRestaurantRequestDto } from '@dto/requests/createRestaurantRequest.dto';
+import { UpdateRestaurantRequestDto } from '@dto/requests/updateRestaurantRequest.dto';
+import { RestaurantResponseDto } from '@dto/responses/restaurantResponse.dto';
 import { IRestaurant } from '@entities/restaurant.entity';
 import { RestaurantService } from '@services/restaurant.service';
-
-import { CreateRestaurantRequestDto } from '../dto/requests/createRestaurantRequest.dto';
-import { UpdateRestaurantRequestDto } from '../dto/requests/updateRestaurantRequest.dto';
-import { RestaurantResponseDto } from '../dto/responses/restaurantResponse.dto';
-import { RestaurantFilter } from '../types/restaurantFilter.type';
-import { handleRequest } from '../utils/handleRequest.util';
-import { pagination } from '../utils/pagination.util';
+import { handleRequest } from '@utils/handleRequest.util';
+import { pagination } from '@utils/pagination.util';
 
 @injectable()
 export class RestaurantHandler {

--- a/nodeeats/src/handlers/user.handler.ts
+++ b/nodeeats/src/handlers/user.handler.ts
@@ -1,15 +1,14 @@
 import { Request, Response } from 'express';
 import { injectable, inject } from 'tsyringe';
 
+import { UserFilter } from '@customTypes/userFilter.type';
+import { CreateUserRequestDto } from '@dto/requests/createUserRequest.dto';
+import { UpdateUserRequestDto } from '@dto/requests/updateUserRequest.dto';
+import { UserResponseDto } from '@dto/responses/userResponse.dto';
+import { IUser } from '@entities/user.entity';
 import { UserService } from '@services/user.service';
-
-import { CreateUserRequestDto } from '../dto/requests/createUserRequest.dto';
-import { UpdateUserRequestDto } from '../dto/requests/updateUserRequest.dto';
-import { UserResponseDto } from '../dto/responses/userResponse.dto';
-import { IUser } from '../entities/user.entity';
-import { UserFilter } from '../types/userFilter.type';
-import { handleRequest } from '../utils/handleRequest.util';
-import { pagination } from '../utils/pagination.util';
+import { handleRequest } from '@utils/handleRequest.util';
+import { pagination } from '@utils/pagination.util';
 
 @injectable()
 export class UserHandler {

--- a/nodeeats/src/index.ts
+++ b/nodeeats/src/index.ts
@@ -4,12 +4,11 @@ import express from 'express';
 
 dotenv.config();
 
+import { registerAllListeners } from '@events/register.listener';
 import { errorMiddleware } from '@middlewares/errorHandler.middleware';
 import { DatabaseProvider } from '@providers/database.provider';
 import { logger } from '@providers/logger.provider';
 import { router } from '@routes/routes';
-
-import { registerAllListeners } from './events/register.listener';
 
 registerAllListeners();
 

--- a/nodeeats/src/middlewares/errorHandler.middleware.ts
+++ b/nodeeats/src/middlewares/errorHandler.middleware.ts
@@ -1,13 +1,15 @@
 import { NextFunction, Request, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 
+import { logger } from '@providers/logger.provider';
+
 export const errorMiddleware = (
   err: Error,
   _req: Request,
   res: Response,
   _next: NextFunction,
 ) => {
-  console.error('Error:', err.message);
+  logger.error('ErrorMiddleware | Error::', JSON.stringify(err));
 
   res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
     error: err.message || 'Internal Server Error',

--- a/nodeeats/src/middlewares/validateRequest.middleware.ts
+++ b/nodeeats/src/middlewares/validateRequest.middleware.ts
@@ -14,6 +14,6 @@ export const validate =
       });
     }
 
-    req.body = result.data; // dados validados e limpos
+    req.body = result.data;
     next();
   };

--- a/nodeeats/src/providers/database.provider.ts
+++ b/nodeeats/src/providers/database.provider.ts
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose';
 
-import { eventEmitter } from './eventEmitter.provider';
+import { eventEmitter } from '@providers/eventEmitter.provider';
 
 export class DatabaseProvider {
   private static DATABASE_URL = process.env.DATABASE_URL;

--- a/nodeeats/src/repositories/category.repository.ts
+++ b/nodeeats/src/repositories/category.repository.ts
@@ -1,9 +1,8 @@
 import mongoose from 'mongoose';
 import { injectable } from 'tsyringe';
 
+import { CategoryFilter } from '@customTypes/categoryFilter.type';
 import { ICategory, CategoryEntity } from '@entities/category.entity';
-
-import { CategoryFilter } from '../types/categoryFilter.type';
 
 @injectable()
 export class CategoryRepository {

--- a/nodeeats/src/repositories/restaurant.repository.ts
+++ b/nodeeats/src/repositories/restaurant.repository.ts
@@ -1,9 +1,8 @@
 import mongoose from 'mongoose';
 import { injectable } from 'tsyringe';
 
+import { RestaurantFilter } from '@customTypes/restaurantFilter.type';
 import { IRestaurant, RestaurantEntity } from '@entities/restaurant.entity';
-
-import { RestaurantFilter } from '../types/restaurantFilter.type';
 
 @injectable()
 export class RestaurantRepository {

--- a/nodeeats/src/repositories/user.repository.ts
+++ b/nodeeats/src/repositories/user.repository.ts
@@ -1,9 +1,8 @@
 import mongoose from 'mongoose';
 import { injectable } from 'tsyringe';
 
-import { IUser, UserEntity } from 'src/entities/user.entity';
-
-import { UserFilter } from '../types/userFilter.type';
+import { UserFilter } from '@customTypes/userFilter.type';
+import { IUser, UserEntity } from '@entities/user.entity';
 
 @injectable()
 export class UserRepository {

--- a/nodeeats/src/routes/category.route.ts
+++ b/nodeeats/src/routes/category.route.ts
@@ -3,11 +3,10 @@ import { container } from 'tsyringe';
 
 import { CategoryHandler } from '@handlers/category.handler';
 import { validate } from '@middlewares/validateRequest.middleware';
-
 import {
   CreateCategoryValidate,
   UpdateCategoryValidate,
-} from '../validates/category.validate';
+} from '@validates/category.validate';
 
 const categoryRouter = Router();
 const categoryHandler = container.resolve(CategoryHandler);

--- a/nodeeats/src/routes/restaurant.route.ts
+++ b/nodeeats/src/routes/restaurant.route.ts
@@ -3,11 +3,10 @@ import { container } from 'tsyringe';
 
 import { RestaurantHandler } from '@handlers/restaurant.handler';
 import { validate } from '@middlewares/validateRequest.middleware';
-
 import {
   CreateRestaurantValidate,
   UpdateRestaurantValidate,
-} from '../validates/restaurant.validate';
+} from '@validates/restaurant.validate';
 
 const restaurantRouter = Router();
 const restaurantHandler = container.resolve(RestaurantHandler);

--- a/nodeeats/src/routes/routes.ts
+++ b/nodeeats/src/routes/routes.ts
@@ -1,9 +1,8 @@
 import { Router } from 'express';
 
+import { categoryRouter } from '@routes/category.route';
 import { restaurantRouter } from '@routes/restaurant.route';
 import { userRouter } from '@routes/user.route';
-
-import { categoryRouter } from './category.route';
 
 export const router = Router();
 

--- a/nodeeats/src/routes/user.route.ts
+++ b/nodeeats/src/routes/user.route.ts
@@ -3,11 +3,10 @@ import { container } from 'tsyringe';
 
 import { UserHandler } from '@handlers/user.handler';
 import { validate } from '@middlewares/validateRequest.middleware';
-
 import {
   CreateUserValidate,
   UpdateUserValidate,
-} from '../validates/user.validate';
+} from '@validates/user.validate';
 
 const userRouter = Router();
 const userHandler = container.resolve(UserHandler);

--- a/nodeeats/src/services/category.service.ts
+++ b/nodeeats/src/services/category.service.ts
@@ -1,10 +1,9 @@
 import { injectable, inject } from 'tsyringe';
 
+import { CategoryFilter } from '@customTypes/categoryFilter.type';
 import { ICategory } from '@entities/category.entity';
+import { eventEmitter } from '@providers/eventEmitter.provider';
 import { CategoryRepository } from '@repositories/category.repository';
-
-import { eventEmitter } from '../providers/eventEmitter.provider';
-import { CategoryFilter } from '../types/categoryFilter.type';
 
 @injectable()
 export class CategoryService {

--- a/nodeeats/src/services/restaurant.service.ts
+++ b/nodeeats/src/services/restaurant.service.ts
@@ -1,10 +1,9 @@
 import { injectable, inject } from 'tsyringe';
 
+import { RestaurantFilter } from '@customTypes/restaurantFilter.type';
+import { IRestaurant } from '@entities/restaurant.entity';
+import { eventEmitter } from '@providers/eventEmitter.provider';
 import { RestaurantRepository } from '@repositories/restaurant.repository';
-import { IRestaurant } from 'src/entities/restaurant.entity';
-
-import { eventEmitter } from '../providers/eventEmitter.provider';
-import { RestaurantFilter } from '../types/restaurantFilter.type';
 
 @injectable()
 export class RestaurantService {

--- a/nodeeats/src/services/user.service.ts
+++ b/nodeeats/src/services/user.service.ts
@@ -1,10 +1,9 @@
 import { injectable, inject } from 'tsyringe';
 
+import { UserFilter } from '@customTypes/userFilter.type';
+import { IUser } from '@entities/user.entity';
+import { eventEmitter } from '@providers/eventEmitter.provider';
 import { UserRepository } from '@repositories/user.repository';
-import { IUser } from 'src/entities/user.entity';
-
-import { eventEmitter } from '../providers/eventEmitter.provider';
-import { UserFilter } from '../types/userFilter.type';
 
 @injectable()
 export class UserService {

--- a/nodeeats/src/utils/handleRequest.util.ts
+++ b/nodeeats/src/utils/handleRequest.util.ts
@@ -1,6 +1,8 @@
 import { Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 
+import { logger } from '@providers/logger.provider';
+
 async function handleRequest<T>(
   res: Response,
   handle: () => Promise<T>,
@@ -9,7 +11,7 @@ async function handleRequest<T>(
     const response = await handle();
     return res.status(StatusCodes.OK).json({ data: response });
   } catch (error) {
-    console.error('Error handling request:', error);
+    logger.error('Error handling request:', error);
     return res
       .status(StatusCodes.BAD_REQUEST)
       .json({ error: (error as Error).message });

--- a/nodeeats/tests/handlers/category.handler.spec.ts
+++ b/nodeeats/tests/handlers/category.handler.spec.ts
@@ -2,17 +2,16 @@ import 'reflect-metadata';
 
 import { Request, Response } from 'express';
 
+import { CategoryResponseDto } from '@dto/responses/categoryResponse.dto';
 import { ICategory } from '@entities/category.entity';
 import { CategoryHandler } from '@handlers/category.handler';
 import { mockCategory, mockCategoryList } from '@mocks/category.mock';
 import { CategoryRepository } from '@repositories/category.repository';
 import { CategoryService } from '@services/category.service';
-
-import { CategoryResponseDto } from '../../src/dto/responses/categoryResponse.dto';
 import {
   CreateCategoryValidate,
   UpdateCategoryValidate,
-} from '../../src/validates/category.validate';
+} from '@validates/category.validate';
 
 jest.mock('@services/category.service');
 

--- a/nodeeats/tests/handlers/restaurant.handler.spec.ts
+++ b/nodeeats/tests/handlers/restaurant.handler.spec.ts
@@ -2,17 +2,16 @@ import 'reflect-metadata';
 
 import { Request, Response } from 'express';
 
+import { RestaurantResponseDto } from '@dto/responses/restaurantResponse.dto';
+import { IRestaurant } from '@entities/restaurant.entity';
 import { RestaurantHandler } from '@handlers/restaurant.handler';
 import { mockRestaurant, mockRestaurantList } from '@mocks/restaurant.mock';
 import { RestaurantRepository } from '@repositories/restaurant.repository';
 import { RestaurantService } from '@services/restaurant.service';
-
-import { RestaurantResponseDto } from '../../src/dto/responses/restaurantResponse.dto';
 import {
   CreateRestaurantValidate,
   UpdateRestaurantValidate,
-} from '../../src/validates/restaurant.validate';
-import { IRestaurant } from '../entities/restaurant.entity';
+} from '@validates/restaurant.validate';
 
 jest.mock('@services/restaurant.service');
 

--- a/nodeeats/tests/handlers/user.handler.spec.ts
+++ b/nodeeats/tests/handlers/user.handler.spec.ts
@@ -1,17 +1,16 @@
 import 'reflect-metadata';
 import { Request, Response } from 'express';
 
+import { UserResponseDto } from '@dto/responses/userResponse.dto';
+import { IUser } from '@entities/user.entity';
 import { UserHandler } from '@handlers/user.handler';
 import { mockUser, mockUserList } from '@mocks/user.mock';
 import { UserRepository } from '@repositories/user.repository';
 import { UserService } from '@services/user.service';
-
-import { UserResponseDto } from '../../src/dto/responses/userResponse.dto';
-import { IUser } from '../entities/user.entity';
 import {
   CreateUserValidate,
   UpdateUserValidate,
-} from '../../src/validates/user.validate';
+} from '@validates/user.validate';
 
 jest.mock('@services/user.service');
 

--- a/nodeeats/tests/jest.setup.ts
+++ b/nodeeats/tests/jest.setup.ts
@@ -1,7 +1,9 @@
 // tests/jest.setup.ts
+import { logger } from '@providers/logger.provider';
+
 /* global jest */
 jest.spyOn(console, 'error').mockImplementation(message => {
   if (!String(message).includes('not found')) {
-    console.warn('Unhandled error:', message);
+    logger.warn('Unhandled error:', message);
   }
 });

--- a/nodeeats/tests/repositories/category.repository.spec.ts
+++ b/nodeeats/tests/repositories/category.repository.spec.ts
@@ -1,8 +1,7 @@
 import 'reflect-metadata';
+import { CategoryEntity } from '@entities/category.entity';
 import { mockCategory, mockCategoryList } from '@mocks/category.mock';
-
 import { CategoryRepository } from '@repositories/category.repository';
-import { CategoryEntity } from 'src/entities/category.entity';
 
 jest.mock('@entities/category.entity');
 

--- a/nodeeats/tests/repositories/restaurant.repository.spec.ts
+++ b/nodeeats/tests/repositories/restaurant.repository.spec.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata';
+import { RestaurantEntity } from '@entities/restaurant.entity';
 import { mockRestaurant, mockRestaurantList } from '@mocks/restaurant.mock';
 import { RestaurantRepository } from '@repositories/restaurant.repository';
-import { RestaurantEntity } from 'src/entities/restaurant.entity';
 
 jest.mock('@entities/restaurant.entity');
 

--- a/nodeeats/tests/repositories/user.repository.spec.ts
+++ b/nodeeats/tests/repositories/user.repository.spec.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata';
+import { UserEntity } from '@entities/user.entity';
 import { mockUser, mockUserList } from '@mocks/user.mock';
 import { UserRepository } from '@repositories/user.repository';
-import { UserEntity } from 'src/entities/user.entity';
 
 jest.mock('@entities/user.entity');
 

--- a/nodeeats/tests/services/category.service.spec.ts
+++ b/nodeeats/tests/services/category.service.spec.ts
@@ -1,7 +1,6 @@
 import 'reflect-metadata';
-import { mockCategory, mockCategoryList } from '@mocks/category.mock';
-
 import { ICategory } from '@entities/category.entity';
+import { mockCategory, mockCategoryList } from '@mocks/category.mock';
 import { CategoryRepository } from '@repositories/category.repository';
 import { CategoryService } from '@services/category.service';
 

--- a/nodeeats/tests/services/restaurant.service.spec.ts
+++ b/nodeeats/tests/services/restaurant.service.spec.ts
@@ -1,9 +1,8 @@
 import 'reflect-metadata';
+import { IRestaurant } from '@entities/restaurant.entity';
 import { mockRestaurant, mockRestaurantList } from '@mocks/restaurant.mock';
 import { RestaurantRepository } from '@repositories/restaurant.repository';
 import { RestaurantService } from '@services/restaurant.service';
-
-import { IRestaurant } from '../entities/restaurant.entity';
 
 jest.mock('@repositories/restaurant.repository');
 

--- a/nodeeats/tests/services/user.service.spec.ts
+++ b/nodeeats/tests/services/user.service.spec.ts
@@ -1,9 +1,8 @@
 import 'reflect-metadata';
+import { IUser } from '@entities/user.entity';
 import { mockUser, mockUserList } from '@mocks/user.mock';
 import { UserRepository } from '@repositories/user.repository';
 import { UserService } from '@services/user.service';
-
-import { IUser } from '../entities/user.entity';
 
 jest.mock('@repositories/user.repository');
 

--- a/nodeeats/tsconfig.json
+++ b/nodeeats/tsconfig.json
@@ -23,18 +23,26 @@
     "noFallthroughCasesInSwitch": true, // Ensure `switch` statements always include `break` to prevent unintended fallthroughs
     "noEmitOnError": true, // OBS: It must be changed for true
     "paths": {
-      "@services/*": ["src/services/*"], // Alias for service modules
-      "@entities/*": ["src/entities/*"], // Alias for model modules
-      "@providers/*": ["src/providers/*"], // Alias for providers modules
-      "@repositories/*": ["src/repositories/*"], // Alias for repositories modules
-      "@handlers/*": ["src/handlers/*"], // Alias for handlers modules
-      "@routes/*": ["src/routes/*"], // Alias for routes modules
-      "@middlewares/*": ["src/middlewares/*"], // Alias for middleware modules
-      "@utils/*": ["src/utils/*"], // Alias for utility modules
-      "@tests/*": ["tests/*"], // Alias for test modules
-      "@mocks/*": ["tests/mocks/*"] // Alias for test modules
+      // Define module path aliases for cleaner imports
+      "@customTypes/*": ["src/types/*"],
+      "@dto/*": ["src/dto/*"],
+      "@entities/*": ["src/entities/*"],
+      "@events/*": ["src/events/*"],
+      "@handlers/*": ["src/handlers/*"],
+      "@listeners/*": ["src/events/listeners/*"],
+      "@mocks/*": ["tests/mocks/*"],
+      "@middlewares/*": ["src/middlewares/*"],
+      "@providers/*": ["src/providers/*"],
+      "@routes/*": ["src/routes/*"],
+      "@requests/*": ["src/dto/requests/*"],
+      "@responses/*": ["src/dto/responses/*"],
+      "@repositories/*": ["src/repositories/*"],
+      "@services/*": ["src/services/*"],
+      "@tests/*": ["tests/*"],
+      "@utils/*": ["src/utils/*"],
+      "@validates/*": ["src/validates/*"]
     }
   },
   "include": ["src/**/*", "tests/**/*"], // Include all TypeScript files inside src and tests folder
-  "exclude": ["dist"] // Exclude "dist" folder from TypeScript compilation
+  "exclude": ["dist", "node_modules"] // Exclude "dist" folder from TypeScript compilation
 }


### PR DESCRIPTION
This PR updates all internal module imports to use namespaced paths (e.g., @services, @repositories, @entities) instead of relative imports.

Changes:
- Updated tsconfig.json to define consistent path aliases.
- Replaced all relative paths (e.g., ../../services) with namespaced imports.
- Ensured consistency across services, repositories, handlers, DTOs, and tests.

Benefits:
- Improved readability and maintainability.
- Easier refactoring and file movement.
- Reduced path resolution issues.

Tested:
- All tests pass successfully.
- Application starts and behaves as expected.
