### PR TITLE
feat(core): add custom error classes and integrate with handleRequest

### DIFF
--- a/nodeeats/jest.config.js
+++ b/nodeeats/jest.config.js
@@ -35,6 +35,8 @@ module.exports = {
   // Path mappings to support TypeScript aliases
   moduleNameMapper: {
     '^src/(.*)$': '<rootDir>/src/$1',
+    '^@customTypes/(.*)$': '<rootDir>/src/types/$1',
+    '^@customErrors/(.*)$': '<rootDir>/src/errors/$1',
     '^@dto/(.*)$': '<rootDir>/src/dto/$1',
     '^@entities/(.*)$': '<rootDir>/src/entities/$1',
     '^@events/(.*)$': '<rootDir>/src/events/$1',
@@ -48,7 +50,6 @@ module.exports = {
     '^@responses/(.*)$': '<rootDir>/src/responses/$1',
     '^@repositories/(.*)$': '<rootDir>/src/repositories/$1',
     '^@services/(.*)$': '<rootDir>/src/services/$1',
-    '^@customTypes/(.*)$': '<rootDir>/src/types/$1',
     '^@utils/(.*)$': '<rootDir>/src/utils/$1',
     '^@validates/(.*)$': '<rootDir>/src/validates/$1',
   },

--- a/nodeeats/src/errors/badRequest.error.ts
+++ b/nodeeats/src/errors/badRequest.error.ts
@@ -1,0 +1,9 @@
+import { StatusCodes } from 'http-status-codes';
+
+import { BaseError } from './baseError.error';
+
+export class BadRequestError extends BaseError {
+  constructor(message = 'Bad request', errors?: unknown) {
+    super(message, StatusCodes.BAD_REQUEST, errors);
+  }
+}

--- a/nodeeats/src/errors/badRequest.error.ts
+++ b/nodeeats/src/errors/badRequest.error.ts
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
 
-import { BaseError } from './baseError.error';
+import { BaseError } from '@customErrors/baseError.error';
 
 export class BadRequestError extends BaseError {
   constructor(message = 'Bad request', errors?: unknown) {

--- a/nodeeats/src/errors/baseError.error.ts
+++ b/nodeeats/src/errors/baseError.error.ts
@@ -1,0 +1,14 @@
+export class BaseError extends Error {
+  public statusCode: number;
+  public errors?: unknown;
+
+  constructor(message: string, statusCode = 500, errors?: unknown) {
+    super(message);
+    this.statusCode = statusCode;
+    this.errors = errors;
+
+    // Fix to instanceof work correctly with custom errors
+    Object.setPrototypeOf(this, new.target.prototype);
+    this.name = this.constructor.name;
+  }
+}

--- a/nodeeats/src/errors/internalServer.error.ts
+++ b/nodeeats/src/errors/internalServer.error.ts
@@ -1,0 +1,9 @@
+import { StatusCodes } from 'http-status-codes';
+
+import { BaseError } from './baseError.error';
+
+export class InternalServerError extends BaseError {
+  constructor(message = 'Internal Server Error') {
+    super(message, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+}

--- a/nodeeats/src/errors/internalServer.error.ts
+++ b/nodeeats/src/errors/internalServer.error.ts
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
 
-import { BaseError } from './baseError.error';
+import { BaseError } from '@customErrors/baseError.error';
 
 export class InternalServerError extends BaseError {
   constructor(message = 'Internal Server Error') {

--- a/nodeeats/src/errors/notFound.error.ts
+++ b/nodeeats/src/errors/notFound.error.ts
@@ -1,0 +1,9 @@
+import { StatusCodes } from 'http-status-codes';
+
+import { BaseError } from './baseError.error';
+
+export class NotFoundError extends BaseError {
+  constructor(message = 'Resource not found') {
+    super(message, StatusCodes.NOT_FOUND);
+  }
+}

--- a/nodeeats/src/errors/notFound.error.ts
+++ b/nodeeats/src/errors/notFound.error.ts
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
 
-import { BaseError } from './baseError.error';
+import { BaseError } from '@customErrors/baseError.error';
 
 export class NotFoundError extends BaseError {
   constructor(message = 'Resource not found') {

--- a/nodeeats/src/errors/zodValidation.error.ts
+++ b/nodeeats/src/errors/zodValidation.error.ts
@@ -1,8 +1,7 @@
-// src/errors/zodValidationError.ts
 import { StatusCodes } from 'http-status-codes';
 import { ZodError } from 'zod';
 
-import { BaseError } from './baseError.error';
+import { BaseError } from '@customErrors/baseError.error';
 
 export class ZodValidationError extends BaseError {
   constructor(zodError: ZodError) {

--- a/nodeeats/src/errors/zodValidation.error.ts
+++ b/nodeeats/src/errors/zodValidation.error.ts
@@ -1,0 +1,24 @@
+// src/errors/zodValidationError.ts
+import { StatusCodes } from 'http-status-codes';
+import { ZodError } from 'zod';
+
+import { BaseError } from './baseError.error';
+
+export class ZodValidationError extends BaseError {
+  constructor(zodError: ZodError) {
+    const formattedErrors: Record<string, string[]> = {};
+
+    for (const issue of zodError.issues) {
+      const path = issue.path.join('.');
+      if (typeof formattedErrors[path] === 'undefined') {
+        formattedErrors[path] = [];
+      }
+      formattedErrors[path].push(issue.message);
+    }
+
+    super('Validation failed', StatusCodes.BAD_REQUEST, {
+      formErrors: [],
+      fieldErrors: formattedErrors,
+    });
+  }
+}

--- a/nodeeats/src/handlers/category.handler.ts
+++ b/nodeeats/src/handlers/category.handler.ts
@@ -1,7 +1,7 @@
-import { NotFoundError } from '@customErrors/notFound.error';
 import { Request, Response } from 'express';
 import { injectable, inject } from 'tsyringe';
 
+import { NotFoundError } from '@customErrors/notFound.error';
 import { CategoryFilter } from '@customTypes/categoryFilter.type';
 import { CreateCategoryRequestDto } from '@dto/requests/createCategoryRequest.dto';
 import { UpdateCategoryRequestDto } from '@dto/requests/updateCategoryRequest.dto';

--- a/nodeeats/src/handlers/category.handler.ts
+++ b/nodeeats/src/handlers/category.handler.ts
@@ -1,3 +1,4 @@
+import { NotFoundError } from '@customErrors/notFound.error';
 import { Request, Response } from 'express';
 import { injectable, inject } from 'tsyringe';
 
@@ -29,7 +30,7 @@ export class CategoryHandler {
     return handleRequest(res, async () => {
       const updateDto = new UpdateCategoryRequestDto(req.body);
       const category = await this.categoryService.update(updateDto);
-      if (!category) throw new Error('Category not found');
+      if (!category) throw new NotFoundError('Category not found');
       return new CategoryResponseDto(category);
     });
   }
@@ -39,7 +40,7 @@ export class CategoryHandler {
       const category = await this.categoryService.getCategoryByCategoryNumber(
         req.params.categoryNumber,
       );
-      if (!category) throw new Error('Category not found');
+      if (!category) throw new NotFoundError('Category not found');
       return new CategoryResponseDto(category);
     });
   }

--- a/nodeeats/src/handlers/restaurant.handler.ts
+++ b/nodeeats/src/handlers/restaurant.handler.ts
@@ -1,3 +1,4 @@
+import { NotFoundError } from '@customErrors/notFound.error';
 import { Request, Response } from 'express';
 import { injectable, inject } from 'tsyringe';
 
@@ -29,7 +30,7 @@ export class RestaurantHandler {
     return handleRequest(res, async () => {
       const updateDto = new UpdateRestaurantRequestDto(req.body);
       const restaurant = await this.restaurantService.update(updateDto);
-      if (!restaurant) throw new Error('Restaurant not found');
+      if (!restaurant) throw new NotFoundError('Restaurant not found');
 
       return new RestaurantResponseDto(restaurant);
     });
@@ -44,7 +45,7 @@ export class RestaurantHandler {
         await this.restaurantService.getRestaurantByRestaurantNumber(
           req.params.restaurantNumber,
         );
-      if (!restaurant) throw new Error('Restaurant not found');
+      if (!restaurant) throw new NotFoundError('Restaurant not found');
 
       return new RestaurantResponseDto(restaurant);
     });

--- a/nodeeats/src/handlers/restaurant.handler.ts
+++ b/nodeeats/src/handlers/restaurant.handler.ts
@@ -1,7 +1,7 @@
-import { NotFoundError } from '@customErrors/notFound.error';
 import { Request, Response } from 'express';
 import { injectable, inject } from 'tsyringe';
 
+import { NotFoundError } from '@customErrors/notFound.error';
 import { RestaurantFilter } from '@customTypes/restaurantFilter.type';
 import { CreateRestaurantRequestDto } from '@dto/requests/createRestaurantRequest.dto';
 import { UpdateRestaurantRequestDto } from '@dto/requests/updateRestaurantRequest.dto';

--- a/nodeeats/src/handlers/user.handler.ts
+++ b/nodeeats/src/handlers/user.handler.ts
@@ -1,3 +1,4 @@
+import { NotFoundError } from '@customErrors/notFound.error';
 import { Request, Response } from 'express';
 import { injectable, inject } from 'tsyringe';
 
@@ -26,7 +27,7 @@ export class UserHandler {
     return handleRequest(res, async () => {
       const updateUserDto = new UpdateUserRequestDto(req.body);
       const user = await this.userService.update(updateUserDto);
-      if (!user) throw new Error('User not found');
+      if (!user) throw new NotFoundError('User not found');
 
       return new UserResponseDto(user);
     });
@@ -40,7 +41,7 @@ export class UserHandler {
       const user = await this.userService.getUserByUserNumber(
         req.params.userNumber,
       );
-      if (!user) throw new Error('User not found');
+      if (!user) throw new NotFoundError('User not found');
 
       return new UserResponseDto(user);
     });

--- a/nodeeats/src/handlers/user.handler.ts
+++ b/nodeeats/src/handlers/user.handler.ts
@@ -1,7 +1,7 @@
-import { NotFoundError } from '@customErrors/notFound.error';
 import { Request, Response } from 'express';
 import { injectable, inject } from 'tsyringe';
 
+import { NotFoundError } from '@customErrors/notFound.error';
 import { UserFilter } from '@customTypes/userFilter.type';
 import { CreateUserRequestDto } from '@dto/requests/createUserRequest.dto';
 import { UpdateUserRequestDto } from '@dto/requests/updateUserRequest.dto';

--- a/nodeeats/src/middlewares/errorHandler.middleware.ts
+++ b/nodeeats/src/middlewares/errorHandler.middleware.ts
@@ -1,7 +1,7 @@
-import { BaseError } from '@customErrors/baseError.error';
 import { NextFunction, Request, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 
+import { BaseError } from '@customErrors/baseError.error';
 import { logger } from '@providers/logger.provider';
 
 export const errorMiddleware = (

--- a/nodeeats/src/middlewares/errorHandler.middleware.ts
+++ b/nodeeats/src/middlewares/errorHandler.middleware.ts
@@ -1,3 +1,4 @@
+import { BaseError } from '@customErrors/baseError.error';
 import { NextFunction, Request, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 
@@ -11,7 +12,14 @@ export const errorMiddleware = (
 ) => {
   logger.error('ErrorMiddleware | Error::', JSON.stringify(err));
 
-  res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-    error: err.message || 'Internal Server Error',
+  if (err instanceof BaseError) {
+    return res.status(err.statusCode).json({
+      message: err.message,
+      errors: err.errors,
+    });
+  }
+
+  return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+    message: 'Internal Server Error',
   });
 };

--- a/nodeeats/src/middlewares/validateRequest.middleware.ts
+++ b/nodeeats/src/middlewares/validateRequest.middleware.ts
@@ -1,17 +1,15 @@
 import { Request, Response, NextFunction } from 'express';
 import { ZodSchema } from 'zod';
 
+import { ZodValidationError } from '../errors/zodValidation.error';
+
 export const validate =
   <T>(schema: ZodSchema<T>) =>
   (req: Request, res: Response, next: NextFunction) => {
     const result = schema.safeParse(req.body);
 
     if (!result.success) {
-      const formattedErrors = result.error.flatten();
-      return res.status(400).json({
-        message: 'Validation failed',
-        errors: formattedErrors,
-      });
+      return next(new ZodValidationError(result.error));
     }
 
     req.body = result.data;

--- a/nodeeats/src/middlewares/validateRequest.middleware.ts
+++ b/nodeeats/src/middlewares/validateRequest.middleware.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { ZodSchema } from 'zod';
 
-import { ZodValidationError } from '../errors/zodValidation.error';
+import { ZodValidationError } from '@customErrors/zodValidation.error';
 
 export const validate =
   <T>(schema: ZodSchema<T>) =>

--- a/nodeeats/src/providers/database.provider.ts
+++ b/nodeeats/src/providers/database.provider.ts
@@ -1,7 +1,7 @@
-import { BaseError } from '@customErrors/baseError.error';
 import { StatusCodes } from 'http-status-codes';
 import mongoose from 'mongoose';
 
+import { BaseError } from '@customErrors/baseError.error';
 import { eventEmitter } from '@providers/eventEmitter.provider';
 
 export class DatabaseProvider {

--- a/nodeeats/src/providers/database.provider.ts
+++ b/nodeeats/src/providers/database.provider.ts
@@ -1,3 +1,5 @@
+import { BaseError } from '@customErrors/baseError.error';
+import { StatusCodes } from 'http-status-codes';
 import mongoose from 'mongoose';
 
 import { eventEmitter } from '@providers/eventEmitter.provider';
@@ -9,7 +11,10 @@ export class DatabaseProvider {
     try {
       mongoose.set('strictQuery', true);
       if (this.DATABASE_URL == null) {
-        throw new Error('DATABASE_URL is not defined');
+        throw new BaseError(
+          'DATABASE_URL is not defined',
+          StatusCodes.INTERNAL_SERVER_ERROR,
+        );
       }
       await mongoose.connect(this.DATABASE_URL);
       eventEmitter.emit('database.connected', 'MongoDB connected successfully');

--- a/nodeeats/src/utils/handleRequest.util.ts
+++ b/nodeeats/src/utils/handleRequest.util.ts
@@ -1,3 +1,5 @@
+import { BaseError } from '@customErrors/baseError.error';
+import { InternalServerError } from '@customErrors/internalServer.error';
 import { Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 
@@ -8,13 +10,23 @@ async function handleRequest<T>(
   handle: () => Promise<T>,
 ): Promise<Response> {
   try {
-    const response = await handle();
-    return res.status(StatusCodes.OK).json({ data: response });
+    const result = await handle();
+    return res.status(StatusCodes.OK).json({ data: result });
   } catch (error) {
-    logger.error('Error handling request:', error);
-    return res
-      .status(StatusCodes.BAD_REQUEST)
-      .json({ error: (error as Error).message });
+    logger.error('HandleRequest | Error:', error);
+
+    if (error instanceof BaseError) {
+      return res.status(error.statusCode).json({
+        message: error.message,
+        errors: error.errors,
+      });
+    }
+
+    const internalError = new InternalServerError();
+    return res.status(internalError.statusCode).json({
+      message: internalError.message,
+      errors: internalError.errors,
+    });
   }
 }
 

--- a/nodeeats/src/utils/handleRequest.util.ts
+++ b/nodeeats/src/utils/handleRequest.util.ts
@@ -1,8 +1,8 @@
-import { BaseError } from '@customErrors/baseError.error';
-import { InternalServerError } from '@customErrors/internalServer.error';
 import { Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 
+import { BaseError } from '@customErrors/baseError.error';
+import { InternalServerError } from '@customErrors/internalServer.error';
 import { logger } from '@providers/logger.provider';
 
 async function handleRequest<T>(

--- a/nodeeats/tests/handlers/category.handler.spec.ts
+++ b/nodeeats/tests/handlers/category.handler.spec.ts
@@ -85,8 +85,8 @@ describe('CategoryHandler', () => {
 
     await categoryHandler.update(req as Request, res as Response);
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Category not found' });
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Category not found' });
   });
 
   it('should get a category by categoryNumber', async () => {
@@ -105,13 +105,13 @@ describe('CategoryHandler', () => {
     });
   });
 
-  it('should return 400 if category is not found by categoryNumber', async () => {
+  it('should return 404 if category is not found by categoryNumber', async () => {
     categoryService.getCategoryByCategoryNumber.mockResolvedValue(null);
 
     await categoryHandler.getCategoryById(req as Request, res as Response);
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Category not found' });
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Category not found' });
   });
 
   it('should return all categories', async () => {

--- a/nodeeats/tests/handlers/restaurant.handler.spec.ts
+++ b/nodeeats/tests/handlers/restaurant.handler.spec.ts
@@ -85,8 +85,8 @@ describe('RestaurantHandler', () => {
 
     await restaurantHandler.update(req as Request, res as Response);
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Restaurant not found' });
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Restaurant not found' });
   });
 
   it('should get a restaurant by restaurantNumber', async () => {
@@ -108,7 +108,7 @@ describe('RestaurantHandler', () => {
     });
   });
 
-  it('should return 400 if restaurant is not found by restaurantNumber', async () => {
+  it('should return 404 if restaurant is not found by restaurantNumber', async () => {
     restaurantService.getRestaurantByRestaurantNumber.mockResolvedValue(null);
 
     await restaurantHandler.getRestaurantByRestaurantNumber(
@@ -116,8 +116,8 @@ describe('RestaurantHandler', () => {
       res as Response,
     );
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Restaurant not found' });
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Restaurant not found' });
   });
 
   it('should return all restaurants', async () => {

--- a/nodeeats/tests/handlers/user.handler.spec.ts
+++ b/nodeeats/tests/handlers/user.handler.spec.ts
@@ -80,8 +80,8 @@ describe('UserHandler', () => {
 
     await userHandler.update(req as Request, res as Response);
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'User not found' });
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ message: 'User not found' });
   });
 
   it('should get a user by userNumber', async () => {
@@ -98,13 +98,13 @@ describe('UserHandler', () => {
     });
   });
 
-  it('should return 400 if user is not found by userNumber', async () => {
+  it('should return 404 if user is not found by userNumber', async () => {
     userService.getUserByUserNumber.mockResolvedValue(null);
 
     await userHandler.getUserByUserNumber(req as Request, res as Response);
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'User not found' });
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ message: 'User not found' });
   });
 
   it('should return all users', async () => {

--- a/nodeeats/tests/utils/handleRequest.spec.ts
+++ b/nodeeats/tests/utils/handleRequest.spec.ts
@@ -31,7 +31,10 @@ describe('handleRequest', () => {
     await handleRequest(res as Response, mockHandler);
 
     expect(mockHandler).toHaveBeenCalled();
-    expect(res.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST);
-    expect(res.json).toHaveBeenCalledWith({ error: errorMessage });
+    expect(res.status).toHaveBeenCalledWith(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Internal Server Error',
+      errors: undefined,
+    });
   });
 });

--- a/nodeeats/tsconfig.json
+++ b/nodeeats/tsconfig.json
@@ -25,6 +25,7 @@
     "paths": {
       // Define module path aliases for cleaner imports
       "@customTypes/*": ["src/types/*"],
+      "@customErrors/*": ["src/errors/*"],
       "@dto/*": ["src/dto/*"],
       "@entities/*": ["src/entities/*"],
       "@events/*": ["src/events/*"],


### PR DESCRIPTION
This PR introduces a centralized error handling strategy based on custom error classes. It includes:

Creation of BaseError and specific subclasses (InternalServerError, ZodValidationError, etc.)

Refactor of handleRequest to support structured error responses using BaseError

Standardization of unexpected errors using InternalServerError

This ensures consistent HTTP status codes, better logging, and standardized error formats across the API.